### PR TITLE
fix: change foreground type to location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## ChangeLog
 
+#### Version 0.7.11 (09.06.2025)
+- [bugfix:] Changed foreground type to location
+
 #### Version 0.7.10 (25.06.2024)
 - [bugfix:] Fix foreground type dataSync
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-background-mode",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Prevent apps from going to sleep in background.",
   "cordova": {
     "id": "cordova-plugin-background-mode",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/katzer/cordova-plugin-background-mode.git"
+    "url": "git+https://github.com/brunochikuji/cordova-plugin-background-mode.git"
   },
   "keywords": [
     "appplant",
@@ -35,7 +35,7 @@
   "author": "Sebastián Katzer",
   "license": "Apache 2.0",
   "bugs": {
-    "url": "https://github.com/katzer/cordova-plugin-background-mode/issues"
+    "url": "https://github.com/brunochikuji/cordova-plugin-background-mode/issues"
   },
-  "homepage": "https://github.com/katzer/cordova-plugin-background-mode#readme"
+  "homepage": "https://github.com/brunochikuji/cordova-plugin-background-mode#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-background-mode"
-        version="0.7.10">
+        version="0.7.11">
 
     <name>BackgroundMode</name>
 
@@ -73,7 +73,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <service
               android:name="de.appplant.cordova.plugin.background.ForegroundService"
-              android:foregroundServiceType="dataSync"
+              android:foregroundServiceType="location"
               android:exported="false">
             </service>
         </config-file>
@@ -87,7 +87,7 @@
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
-            <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
         </config-file>
 
         <source-file

--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -131,7 +131,7 @@ public class ForegroundService extends Service {
 
         if (!isSilent) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                startForeground(NOTIFICATION_ID, makeNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+                startForeground(NOTIFICATION_ID, makeNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION);
             } else {
                 startForeground(NOTIFICATION_ID, makeNotification());
             }


### PR DESCRIPTION
Release 0.7.11

-> Changed foreground type to location

In upcoming versions of the plugin, it will be possible to configure the foregroundType for greater compatibility with different types of apps.

If you prefer using type_location, please use the previous version.